### PR TITLE
Allow beta to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
The current beta environment is having some issues.

Seems related to this:
https://github.com/emberjs/ember.js/issues/15468