### PR TITLE
Updated for jQuery-ui 1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,27 @@ export default Ember.Component.extend({
 });
 ```
 
+## Build Configuration
+
+By default, the [bower dependencies for Gridstack](https://github.com/troolee/gridstack.js#requirements)
+will be installed automatically.
+
+### Exclude Optional Dependencies
+
+You can exclude the optional [jquery.ui.touch-punch](https://github.com/furf/jquery-ui-touch-punch) dependency by using
+the following configuration in your `config/environment.js`:
+
+```js
+// config.environment.js
+module.exports = function(environment) {
+  return {
+    'ember-gridstack': {
+      // Exclude the optional jquery.ui.touch-punch dependency
+      exclude: ['jquery.ui.touch-punch']
+    }
+  };
+```
+
+
 [build-badge]: https://travis-ci.org/yahoo/ember-gridstack.svg?branch=master
 [build]: https://travis-ci.org/yahoo/ember-gridstack

--- a/blueprints/ember-gridstack/index.js
+++ b/blueprints/ember-gridstack/index.js
@@ -3,19 +3,28 @@ module.exports = {
   normalizeEntityName: function() {}, // Required for `ember install` to run without error
 
   afterInstall: function() {
-    return this.addBowerPackagesToProject([
+    let config = (this.project.config(process.env.EMBER_ENV) || {})['ember-gridstack'] || {};
+    let packages = [
       {
         name: 'jquery-ui',
-        target: '~1.11.4'
+        target: '~1.12.1'
       },
       {
         name: 'lodash',
-        target: '~4.13.1'
+        target: '^4.13.1'
       },
       {
         name: 'gridstack',
-        target: '~0.2.5'
-      }
-    ]);
+        target: '~0.2.6'
+      },
+    ];
+
+    if (!(config.exclude && config.exclude.indexOf('jquery.ui.touch-punch') >= 0)) {
+      packages.push({
+        name: 'jquery.ui.touch-punch',
+        target: '^0.3.0'
+      });
+    }
+    return this.addBowerPackagesToProject(packages);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -4,12 +4,13 @@
     "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3",
     "gridstack": "^0.2.6",
-    "jquery-ui": "1.11.4",
-    "lodash": "3.7.0"
+    "jquery-ui": "1.12.1",
+    "lodash": "3.7.0",
+    "jquery.ui.touch-punch": "0.3.0"
   },
   "resolutions": {
     "lodash": "3.7.0",
     "jquery": ">= 1.7.0 < 4.0.0",
-    "jquery-ui": "1.11.4"
+    "jquery-ui": "1.12.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,12 +14,32 @@ module.exports = {
     });
 
     // JQuery UI
-    ['core', 'widget', 'mouse', 'draggable', 'resizable'].forEach(function(module) {
+    app.import({
+      development: app.bowerDirectory + '/jquery-ui/jquery-ui.js',
+      production:  app.bowerDirectory + '/jquery-ui/jquery-ui.min.js'
+    });
+
+    ['widget', 'plugin'].forEach(function(module) {
       app.import({
         development: app.bowerDirectory + '/jquery-ui/ui/' + module + '.js',
         production:  app.bowerDirectory + '/jquery-ui/ui/minified/' + module + '.min.js'
       });
     });
+
+    ['mouse', 'draggable', 'resizable'].forEach(function(module) {
+      app.import({
+        development: app.bowerDirectory + '/jquery-ui/ui/widgets/' + module + '.js',
+        production:  app.bowerDirectory + '/jquery-ui/ui/widgets/minified/' + module + '.min.js'
+      });
+    });
+
+    let config = this.getOptions();
+    if (config.exclude.indexOf('jquery.ui.touch-punch') < 0) {
+      app.import({
+        development: app.bowerDirectory + '/jquery.ui.touch-punch/dist/jquery.ui.touch-punch.js',
+        production: app.bowerDirectory + '/jquery.ui.touch-punch/dist/jquery.ui.touch-punch.min.js'
+      });
+    }
 
 
     // Gridstack
@@ -29,5 +49,16 @@ module.exports = {
     });
     app.import(app.bowerDirectory + '/gridstack/dist/gridstack.css');
 
+  },
+
+  getOptions() {
+    let projectConfig = (this.project.config(process.env.EMBER_ENV) || {})['ember-gridstack'] || {};
+
+    let config = Object.assign({}, {
+      exclude: [],
+    }, projectConfig);
+    config.exclude = config.exclude || [];
+
+    return config;
   }
 };


### PR DESCRIPTION
Based on work by Brand Martin:
- Rebased off latest yahoo/ember-gridster master
- Removed commits that started the gridster 0.3.0 work
- Squashed commit.
- Add support for the optional `jquery.ui.touch-punch` dependency.

TODO
=====
- [x] Add `jquery.ui.touch` to default blueprint
- [x] Add config option for optional include of `jquery.ui.touch` https://github.com/yahoo/ember-gridstack/pull/9#discussion_r133494048