### PR TITLE
Support Ember 2.14+ change to didUpdateAttrs

### DIFF
--- a/addon/components/grid-stack.js
+++ b/addon/components/grid-stack.js
@@ -68,12 +68,10 @@ export default Ember.Component.extend({
   /**
    * @method didUpdateAttrs
    */
-  didUpdateAttrs(changeSet) {
-    if (changeSet.newAttrs.options) {
-      // Reset gridstack to pick up latest option changes
-      this._destroyGridStack();
-      this._createGridStack();
-    }
+  didUpdateAttrs() {
+    // Reset gridstack to pick up latest option changes
+    this._destroyGridStack();
+    this._createGridStack();
   },
 
   /**


### PR DESCRIPTION
Looks like we missed this one:
https://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks

Arguments are no longer provided to `didUpdateAttrs` in `2.14+`.

We were using `newAttrs` as an optimization to refresh gridstack only when `options` changes, but the only attributes the `grid-stack` component receives are `options` and action handlers. It's pretty safe to assume when `didUpdateAttrs` is called, it's because of `options`.

If we decide we _do_ care about only `options` changing, we can look at https://github.com/workmanw/ember-diff-attrs.