### PR TITLE
Refactor jquery-ui dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,26 +7,25 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    // Lodash
+    // lodash
     app.import({
       development: app.bowerDirectory + '/lodash/lodash.js',
       production:  app.bowerDirectory + '/lodash/dist/lodash.min.js'
     });
 
-    // JQuery UI
-    app.import({
-      development: app.bowerDirectory + '/jquery-ui/jquery-ui.js',
-      production:  app.bowerDirectory + '/jquery-ui/jquery-ui.min.js'
-    });
-
-    ['widget', 'plugin'].forEach(function(module) {
+    // jquery-ui dependencies needed by gridstack.js
+    // https://github.com/gridstack/gridstack.js/blob/v0.2.6/src/gridstack.js#L10
+    [ 'version', 'data', 'disable-selection', 'focusable', 'escape-selector', 'form',
+      'ie', 'keycode', 'labels', 'jquery-1-7', 'plugin', 'safe-active-element',
+      'safe-blur', 'scroll-parent', 'tabbable', 'unique-id', 'widget'
+    ].forEach(function(module) {
       app.import({
         development: app.bowerDirectory + '/jquery-ui/ui/' + module + '.js',
         production:  app.bowerDirectory + '/jquery-ui/ui/minified/' + module + '.min.js'
       });
     });
 
-    ['mouse', 'draggable', 'resizable'].forEach(function(module) {
+    [ 'mouse', 'draggable', 'droppable', 'resizable' ].forEach(function(module) {
       app.import({
         development: app.bowerDirectory + '/jquery-ui/ui/widgets/' + module + '.js',
         production:  app.bowerDirectory + '/jquery-ui/ui/widgets/minified/' + module + '.min.js'

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,11 +1,14 @@
 import Ember from 'ember';
 
+const { get } = Ember;
+
 export default Ember.Controller.extend({
-  items: Ember.A([1, 2, 3]),
+  items: Ember.A([0, 1, 2]),
 
   actions: {
     changeItems() {
-      this.get('items').pushObject(4);
+      let items = get(this, 'items');
+      items.pushObject(get(items, 'length') + 1);
     }
   }
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -3,3 +3,11 @@
   transform: none !important;
   zoom: 50%;
 }
+
+.grid-stack-item {
+  border: 1px solid #000000;
+}
+
+.new-item-btn {
+  margin: 8px 0;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,7 @@
 <h2 id="title">Welcome to Ember Gridstack</h2>
 
+<button class="new-item-btn" onclick={{action 'changeItems'}}>+ New Item</button>
+
 {{#grid-stack classNames='grid-stack' onChange=(action (mut test) true)}}
   {{#each items as |item|}}
     {{#grid-stack-item}}
@@ -8,6 +10,5 @@
   {{/each}}
 {{/grid-stack}}
 
-<button onclick={{action 'changeItems'}}>+ New Item</button>
 
 {{outlet}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,7 +4,9 @@
 
 {{#grid-stack classNames='grid-stack' onChange=(action (mut test) true)}}
   {{#each items as |item|}}
-    {{#grid-stack-item}}
+    {{#grid-stack-item
+       options=(hash x=0 y=item)
+    }}
       {{item}}
     {{/grid-stack-item}}
   {{/each}}


### PR DESCRIPTION
Currently, `ember-gridstack` pulls in [all of jquery-ui](https://github.com/yahoo/ember-gridstack/blob/master/index.js#L18). Since, `jquery-ui` checks for [define.amd](https://github.com/jquery/jquery-ui/blob/master/ui/data.js#L16) to determine if it can register a module and the `ember-loader` does [not yet support this flag](https://github.com/ember-cli/loader.js/issues/60), all the jquery-ui modules are included globally. This pulls unnecessarily `jquery-ui` modules like `datepicker` that can conflict with other libraries (such as [ember-cli-bootstrap-datepicker](https://github.com/soulim/ember-cli-bootstrap-datepicker)).


This PR refactors the `jquery-ui` dependency to include only the `jquery-ui` modules that are required by gridstack.

It also cleans up the dummy app a bit.