### PR TITLE
bower registry depricated

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
+  "registry": "https://registry.bower.io",
   "analytics": false
 }

--- a/blueprints/ember-gridstack/index.js
+++ b/blueprints/ember-gridstack/index.js
@@ -17,6 +17,9 @@ module.exports = {
         name: 'gridstack',
         target: '~0.2.6'
       },
+      blueprintOptions: {
+        saveDev: true
+      },
     ];
 
     if (!(config.exclude && config.exclude.indexOf('jquery.ui.touch-punch') >= 0)) {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-gridstack",
   "dependencies": {
-    "ember": "~2.10.0",
+    "ember": "~2.16.2",
     "ember-cli-shims": "0.1.3",
     "gridstack": "^0.2.6",
     "jquery-ui": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-assign-polyfill": "2.0.1",
-    "ember-cli": "2.10.0",
+    "ember-cli": "2.16.2",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",


### PR DESCRIPTION
when trying to run `ember install ember-gridstack` it gives this error:

`Request to https://bower.herokuapp.com/packages/lodash failed with 502`