### PR TITLE
use updated bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
+  "registry": "https://registry.bower.io",
   "analytics": false
 }


### PR DESCRIPTION
when trying to run `ember install ember-gridstack` it gives this error:

`Request to https://bower.herokuapp.com/packages/lodash failed with 502`