### PR TITLE
bump minor version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-gridstack",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Ember Gridstack",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Changes since previous release
- explicit specification of bower registry
- upgrade ember to 2.18
- upgrade to the latest gridstack v0.4.0

resolves #23 