### PR TITLE
Selectively reenable grid items during creation

### DIFF
--- a/addon/components/grid-stack.js
+++ b/addon/components/grid-stack.js
@@ -122,7 +122,23 @@ export default Component.extend({
     // Since destroying gridstack disables it,
     // we must manually enable it
     if (!get(this, 'options.staticGrid')) {
-      get(this, 'gridStack').enable();
+      let grid = get(this, 'gridStack');
+      let itemClass = grid.opts.itemClass;
+      this.$().children(`.${itemClass}`).each((i, el) => {
+        let $el = this.$(el);
+
+        // only enable items that are supposed to mobile
+        let noMove = $el.attr('data-gs-no-move');
+        let noResize = $el.attr('data-gs-no-resize');
+
+        if (!noMove) {
+          grid.movable(el, true);
+        }
+
+        if (!noResize) {
+          grid.resizable(el, true);
+        }
+      });
     }
 
     get(this, 'gridStackEvents').forEach(eventName => {

--- a/tests/integration/components/grid-stack-test.js
+++ b/tests/integration/components/grid-stack-test.js
@@ -202,4 +202,21 @@ module('Integration | Component | grid stack', function(hooks) {
     run(() => this.get('items').pushObject(2));
     run(() => this.get('items').removeObject(2));
   });
+
+  test('gridstack items with noMove/Resize', async function(assert) {
+    await render(hbs`
+      <GridStack>
+        <GridStackItem
+          @options={{hash x=0 y=0 noMove='true' noResize='true'}}
+        >
+          Test widget
+        </GridStackItem>
+      </GridStack>
+    `);
+
+    assert.dom('.grid-stack .grid-stack-item.ui-draggable.ui-resizable.ui-draggable-disabled.ui-resizable-disabled').exists(
+      { count: 1 },
+      'grid-stack-item noResize and noMove properties are applied'
+    );
+  });
 });


### PR DESCRIPTION
This PR addresses https://github.com/yahoo/ember-gridstack/issues/34

Instead enabling every element on grid creation, we iterate through them and only make them movable if they don't have `noMove` set, and resizable if they don't have `noResize` set.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
