### PR TITLE
Fix conflicts with other jquery addons.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    app.import('node_modules/gridstack/dist/gridstack.all.js');
+
+    app.import('node_modules/gridstack/dist/jquery-ui.js');
+    app.import('node_modules/gridstack/dist/gridstack.js');
+    app.import('node_modules/gridstack/dist/gridstack.jQueryUI.js');
 
     app.import('node_modules/gridstack/dist/gridstack.css');
     app.import('node_modules/gridstack/dist/gridstack-extra.css');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,6 +1864,51 @@
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
       "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog=="
     },
+    "@ember/jquery": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/jquery/-/jquery-1.1.0.tgz",
+      "integrity": "sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "ember-cli-babel": "^7.11.1",
+        "ember-cli-version-checker": "^3.1.3",
+        "jquery": "^3.4.1",
+        "resolve": "^1.11.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+          "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.10.0"
+          }
+        }
+      }
+    },
     "@ember/optional-features": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ember/optional-features/-/optional-features-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gridstack": "^1.1.0"
   },
   "devDependencies": {
+    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,6 +1,6 @@
 {
   "application-template-wrapper": false,
   "default-async-observers": true,
-  "jquery-integration": false,
+  "jquery-integration": true,
   "template-only-glimmer-components": true
 }


### PR DESCRIPTION
See https://github.com/gridstack/gridstack.js/issues/1191

I experience the bug described above when using gridstack through ember-gridstack in an app which also uses other jquery addons.

For instance when trying to use `ember-cli-bootstrap-datetimepicker`:
`TypeError: $.fn.datetimepicker is undefined`

Since gridstack.js uses jquery anyways for now, it shouldn't be a problem to add it our dependencies again for the time being.

--------------

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
