### PR TITLE
fix: don't trigger events due to teardown

### DIFF
--- a/addon/components/grid-stack.js
+++ b/addon/components/grid-stack.js
@@ -159,7 +159,7 @@ export default class GridStackComponent extends Component {
         el.remove(); // in batch mode engine.removeNode doesn't call back to remove DOM
       }
     });
-    if (triggerEvent) {
+    if (triggerEvent && !this.isDestroying && !this.isDestroyed) {
       this.gridStack?._triggerRemoveEvent();
       this.gridStack?._triggerChangeEvent();
     }


### PR DESCRIPTION
This PR fixes an issue where `onChange` events were fired due to tearing down a gridstack component.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
